### PR TITLE
fix for issue#10

### DIFF
--- a/lib/dotiw.rb
+++ b/lib/dotiw.rb
@@ -17,8 +17,8 @@ module ActionView
         DOTIW::TimeHash.new((from_time - to_time).abs, from_time, to_time, options).to_hash
       end
 
-      def distance_of_time(seconds, options = {})
-        display_time_in_words DOTIW::TimeHash.new(seconds).to_hash, options
+      def distance_of_time(seconds, include_seconds = false, options = {})
+        display_time_in_words DOTIW::TimeHash.new(seconds).to_hash, include_seconds, options
       end
 
       def distance_of_time_in_words(from_time, to_time, include_seconds = false, options = {})


### PR DESCRIPTION
there is a test failing:

<pre>
1) A better distance_of_time_in_words with output options should be 1 year, 2 months, 3 days, 4 hours, 5 minutes, and 6 seconds
     Failure/Error: distance_of_time_in_words(start, finish, true, options).should eql(output)
       
       expected "1 year, 2 months, 3 days, 4 hours, 5 minutes, and 6 seconds"
            got "1 year, 2 months, 3 days, 4 hours, 5 minutes, and 5 seconds"
       
       (compared using eql?)
     # ./spec/lib/dotiw_spec.rb:212:in `block (4 levels) in <top (required)>'
</pre>

But I guess it is not because of my changes.