### PR TITLE
support a single argument to be more backwards-compatible with the original distance_of_time_in_words

### DIFF
--- a/lib/dotiw.rb
+++ b/lib/dotiw.rb
@@ -21,8 +21,9 @@ module ActionView
         display_time_in_words DOTIW::TimeHash.new(seconds).to_hash, options
       end
 
-      def distance_of_time_in_words(from_time, to_time, include_seconds = false, options = {})
+      def distance_of_time_in_words(from_time, to_time = 0, include_seconds = false, options = {})
         return old_distance_of_time_in_words(from_time, to_time, include_seconds, options) if options.delete(:vague)
+        return distance_of_time(from_time, options) if to_time == 0
         hash = distance_of_time_in_words_hash(from_time, to_time, options)
         display_time_in_words(hash, include_seconds, options)
       end

--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,1 +1,0 @@
-require 'dotiw'

--- a/spec/lib/dotiw_spec.rb
+++ b/spec/lib/dotiw_spec.rb
@@ -135,6 +135,24 @@ describe "A better distance_of_time_in_words" do
         end
       end
     end # :accumulate_on
+    
+    describe "without finish time" do
+      # A missing finish argument should default to zero, essentially returning
+      # the equivalent of distance_of_time in order to be backwards-compatible
+      # with the original rails distance_of_time_in_words helper.
+      [
+        [5.minutes.to_i, "5 minutes"],
+        [10.minutes.to_i, "10 minutes"],
+        [1.hour.to_i, "1 hour"],
+        [4.weeks.to_i, "28 days"],
+        [24.weeks.to_i, "5 months and 15 days"]
+      ].each do |start, output|
+        it "should be #{output}" do
+          distance_of_time_in_words(start).should eql(output)
+        end
+      end
+    end
+    
   end
 
   describe "with output options" do


### PR DESCRIPTION
support a single argument to be more backwards-compatible with the original
distance_of_time_in_words by calling distance_of_time