### PR TITLE
better I18n support

### DIFF
--- a/dotiw.gemspec
+++ b/dotiw.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary = "Better distance_of_time_in_words for Rails"
   s.email = "radarlistener@gmail.com"
 
-  s.add_dependency "actionpack", "~> 3.0.0"
+  s.add_dependency "actionpack", "~> 3.0"
   
   s.add_development_dependency "bundler", "~> 1.0.0"
   s.add_development_dependency "rspec", "~> 2.0"

--- a/lib/dotiw.rb
+++ b/lib/dotiw.rb
@@ -61,7 +61,14 @@ module ActionView
 
           output = []
 
-          time_measurements = Hash[*time_measurements.first] if options.delete(:highest_measure_only)
+          highest_measures = options.delete(:highest_measures)
+          highest_measures = 1 if options.delete(:highest_measure_only)
+          if highest_measures
+            keys = [:years, :months, :days, :hours, :minutes, :seconds]
+            first_index = keys.index(time_measurements.first.first)
+            keys = keys[first_index, highest_measures]
+            time_measurements.delete_if { |measure, key| !keys.include?(measure) }
+          end
 
           time_measurements.each do |measure, key|
             name = options[:singularize] == :always || hash[key].between?(-1, 1) ? key.singularize : key

--- a/lib/dotiw.rb
+++ b/lib/dotiw.rb
@@ -39,20 +39,11 @@ module ActionView
           options.symbolize_keys!
           I18n.locale = options[:locale] if options[:locale]
 
-          time_measurements = ActiveSupport::OrderedHash.new
-          time_measurements[:years]   = I18n.t(:years,   :default => "years")
-          time_measurements[:months]  = I18n.t(:months,  :default => "months")
-          time_measurements[:weeks]   = I18n.t(:weeks,   :default => "weeks")
-          time_measurements[:days]    = I18n.t(:days,    :default => "days")
-          time_measurements[:hours]   = I18n.t(:hours,   :default => "hours")
-          time_measurements[:minutes] = I18n.t(:minutes, :default => "minutes")
-          time_measurements[:seconds] = I18n.t(:seconds, :default => "seconds")
-
           hash.delete(:seconds) if !include_seconds && hash[:minutes]
 
           # Remove all the values that are nil or excluded. Keep the required ones.
-          time_measurements.delete_if do |key, word|
-            hash[key].nil? || hash[key].zero? || (!options[:except].nil? && options[:except].include?(key.to_s)) ||
+          hash.delete_if do |key, value|
+            value.nil? || value.zero? || (!options[:except].nil? && options[:except].include?(key.to_s)) ||
               (options[:only] && !options[:only].include?(key.to_s))
           end
 
@@ -63,12 +54,12 @@ module ActionView
           highest_measures = 1 if options.delete(:highest_measure_only)
           if highest_measures
             keys = [:years, :months, :days, :hours, :minutes, :seconds]
-            first_index = keys.index(time_measurements.first.first)
+            first_index = keys.index(hash.first.first)
             keys = keys[first_index, highest_measures]
-            time_measurements.delete_if { |key, word| !keys.include?(key) }
+            hash.delete_if { |key, value| !keys.include?(key) }
           end
 
-          output = time_measurements.map { |key, word| hash[key].to_s + ' ' + I18n.t(key, :count => hash[key], :default => key.to_s) }
+          output = hash.map { |key, value| value.to_s + ' ' + I18n.t(key, :count => value, :default => key.to_s) }
 
           # maybe only grab the first few values
           if options[:precision]

--- a/lib/dotiw.rb
+++ b/lib/dotiw.rb
@@ -48,18 +48,16 @@ module ActionView
           time_measurements[:minutes] = I18n.t(:minutes, :default => "minutes")
           time_measurements[:seconds] = I18n.t(:seconds, :default => "seconds")
 
-          hash.delete(time_measurements[:seconds]) if !include_seconds && hash[time_measurements[:minutes]]
+          hash.delete(:seconds) if !include_seconds && hash[:minutes]
 
           # Remove all the values that are nil or excluded. Keep the required ones.
-          time_measurements.delete_if do |measure, key|
-            hash[key].nil? || hash[key].zero? || (!options[:except].nil? && options[:except].include?(key)) ||
-              (options[:only] && !options[:only].include?(key))
+          time_measurements.delete_if do |key, word|
+            hash[key].nil? || hash[key].zero? || (!options[:except].nil? && options[:except].include?(key.to_s)) ||
+              (options[:only] && !options[:only].include?(key.to_s))
           end
 
           options.delete(:except)
           options.delete(:only)
-
-          output = []
 
           highest_measures = options.delete(:highest_measures)
           highest_measures = 1 if options.delete(:highest_measure_only)
@@ -67,15 +65,10 @@ module ActionView
             keys = [:years, :months, :days, :hours, :minutes, :seconds]
             first_index = keys.index(time_measurements.first.first)
             keys = keys[first_index, highest_measures]
-            time_measurements.delete_if { |measure, key| !keys.include?(measure) }
+            time_measurements.delete_if { |key, word| !keys.include?(key) }
           end
 
-          time_measurements.each do |measure, key|
-            name = options[:singularize] == :always || hash[key].between?(-1, 1) ? key.singularize : key
-            output += ["#{hash[key]} #{name}"]
-          end
-
-          options.delete(:singularize)
+          output = time_measurements.map { |key, word| hash[key].to_s + ' ' + I18n.t(key, :count => hash[key], :default => key.to_s) }
 
           # maybe only grab the first few values
           if options[:precision]

--- a/lib/dotiw/time_hash.rb
+++ b/lib/dotiw/time_hash.rb
@@ -14,8 +14,6 @@ module DOTIW
       self.to_time    = to_time   || (self.from_time + self.distance.seconds)
       self.smallest, self.largest = [self.from_time, self.to_time].minmax
 
-      I18n.locale = options[:locale] if options[:locale]
-
       build_time_hash
     end
 
@@ -50,27 +48,27 @@ module DOTIW
       end
 
       def build_seconds
-        output[I18n.t(:seconds, :default => "seconds")] = distance.to_i
+        output[:seconds] = distance.to_i
         self.distance = 0
       end
 
       def build_minutes
-        output[I18n.t(:minutes, :default => "minutes")], self.distance = distance.divmod(1.minute)
+        output[:minutes], self.distance = distance.divmod(1.minute)
       end
 
       def build_hours
-        output[I18n.t(:hours, :default => "hours")], self.distance = distance.divmod(1.hour)
+        output[:hours], self.distance = distance.divmod(1.hour)
       end
 
       def build_days
-        output[I18n.t(:days, :default => "days")], self.distance = distance.divmod(1.day)
+        output[:days], self.distance = distance.divmod(1.day)
       end
 
       def build_months
         build_years_months_days
 
-        if (years = output.delete(I18n.t(:years, :default => "years"))) > 0
-          output[I18n.t(:months, :default => "months")] += (years * 12)
+        if (years = output.delete(:years)) > 0
+          output[:months] += (years * 12)
         end
       end
 
@@ -96,9 +94,9 @@ module DOTIW
           months += 12
         end
 
-        output[I18n.t(:years,   :default => "years")]   = years
-        output[I18n.t(:months,  :default => "months")]  = months
-        output[I18n.t(:days,    :default => "days")]    = days
+        output[:years]   = years
+        output[:months]  = months
+        output[:days]    = days
 
         total_days, self.distance = (from_time - to_time).abs.divmod(1.day)
       end

--- a/lib/dotiw/time_hash.rb
+++ b/lib/dotiw/time_hash.rb
@@ -7,7 +7,7 @@ module DOTIW
     attr_accessor :distance, :smallest, :largest, :from_time, :to_time, :options
 
     def initialize(distance, from_time = nil, to_time = nil, options = {})
-      self.output     = {}
+      self.output     = ActiveSupport::OrderedHash.new
       self.options    = options
       self.distance   = distance
       self.from_time  = from_time || Time.now

--- a/spec/lib/dotiw_spec.rb
+++ b/spec/lib/dotiw_spec.rb
@@ -35,12 +35,12 @@ describe "A better distance_of_time_in_words" do
         describe name do
           it "exactly" do
             hash = distance_of_time_in_words_hash(Time.now, Time.now + 1.send(name))
-            hash[name.to_s].should eql(1)
+            hash[name].should eql(1)
           end
 
           it "two" do
             hash = distance_of_time_in_words_hash(Time.now, Time.now + 2.send(name))
-            hash[name.to_s].should eql(2)
+            hash[name].should eql(2)
           end
         end
       end
@@ -48,37 +48,20 @@ describe "A better distance_of_time_in_words" do
       it "should be happy with lots of measurements" do
         hash = distance_of_time_in_words_hash(Time.now,
                                               Time.now + 1.year + 2.months + 3.days + 4.hours + 5.minutes + 6.seconds)
-        hash["years"].should eql(1)
-        hash["months"].should eql(2)
-        hash["days"].should eql(3)
-        hash["hours"].should eql(4)
-        hash["minutes"].should eql(5)
-        hash["seconds"].should eql(6)
+        hash[:years].should eql(1)
+        hash[:months].should eql(2)
+        hash[:days].should eql(3)
+        hash[:hours].should eql(4)
+        hash[:minutes].should eql(5)
+        hash[:seconds].should eql(6)
       end
 
-      it "debe estar contento con las mediciones en español" do
-        hash = distance_of_time_in_words_hash(Time.now,
-                                              Time.now + 1.year + 2.months + 3.days + 4.hours + 5.minutes + 6.seconds,
-                                              :locale => "es")
-        hash["años"].should eql(1)
-        hash["meses"].should eql(2)
-        hash["días"].should eql(3)
-        hash["horas"].should eql(4)
-        hash["minutos"].should eql(5)
-        hash["segundos"].should eql(6)
-      end
-
-      it "debe hablar español" do
-        I18n.locale = :es
-        hash = distance_of_time_in_words_hash(Time.now, Time.now + 5.days)
-        hash["días"].should eql(5)
-      end
     end
   end
 
   describe "real version" do
     it "debe hablar español" do
-      distance_of_time_in_words(Time.now, Time.now + 5.days, true, :locale => "es").should eql("5 días")
+      distance_of_time_in_words(Time.now, Time.now + 3.days, true, :locale => "ru").should eql("3 дня")
     end
 
     [
@@ -124,11 +107,7 @@ describe "A better distance_of_time_in_words" do
         [Time.now,
          Time.now + 2.day + 10000.hour + 10.second,
          :months,
-         "13 months, 16 hours, and 10 seconds"],
-        [Time.now,
-         Time.now + 2.day + 10000.hour + 10.second,
-         :years,
-         "1 year, 1 month, 22 days, 16 hours, and 10 seconds"]
+         "13 months, 16 hours, and 10 seconds"]
       ].each do |start, finish, accumulator, output|
         it "should be #{output}" do
           distance_of_time_in_words(start, finish, true, :accumulate_on => accumulator).should eql(output)
@@ -203,10 +182,6 @@ describe "A better distance_of_time_in_words" do
         Time.now + 1.hour + 2.minutes + 3.seconds,
         { :highest_measure_only => true },
         "1 hour"],
-      [Time.now,
-       Time.now + 2.year + 3.months + 4.days + 5.hours + 6.minutes + 7.seconds,
-       { :singularize => :always },
-       "2 year, 3 month, 4 day, 5 hour, 6 minute, and 7 second"],
       [Time.now,
        Time.now + 1.hours + 2.minutes + 3.seconds,
        { :highest_measures => 1 },

--- a/spec/lib/dotiw_spec.rb
+++ b/spec/lib/dotiw_spec.rb
@@ -206,7 +206,27 @@ describe "A better distance_of_time_in_words" do
       [Time.now,
        Time.now + 2.year + 3.months + 4.days + 5.hours + 6.minutes + 7.seconds,
        { :singularize => :always },
-       "2 year, 3 month, 4 day, 5 hour, 6 minute, and 7 second"]
+       "2 year, 3 month, 4 day, 5 hour, 6 minute, and 7 second"],
+      [Time.now,
+       Time.now + 1.hours + 2.minutes + 3.seconds,
+       { :highest_measures => 1 },
+       "1 hour"],
+      [Time.now,
+       Time.now + 2.year + 3.months + 4.days + 5.hours + 6.minutes + 7.seconds,
+       { :highest_measures => 3 },
+       "2 years, 3 months, and 4 days"],
+      [Time.now,
+       Time.now + 2.year + 3.weeks + 4.days + 5.hours + 6.minutes + 7.seconds,
+       { :highest_measures => 3 },
+       "2 years and 25 days"],
+      [Time.now,
+       Time.now + 4.days + 6.minutes + 7.seconds,
+       { :highest_measures => 3 },
+       "4 days and 6 minutes"],
+      [Time.now,
+       Time.now + 1.year + 2.weeks,
+       { :highest_measures => 3 },
+       "1 year and 14 days"],
     ].each do |start, finish, options, output|
       it "should be #{output}" do
         distance_of_time_in_words(start, finish, true, options).should eql(output)

--- a/spec/translations/en.yml
+++ b/spec/translations/en.yml
@@ -1,11 +1,25 @@
 en:
-  seconds: seconds
-  minutes: minutes
-  hours: hours
-  days: days
-  weeks: weeks
-  months: months
-  years: years
+  seconds: 
+    one: second
+    other: seconds
+  minutes: 
+    one: minute
+    other: minutes
+  hours: 
+    one: hour
+    other: hours
+  days: 
+    one: day
+    other: days
+  weeks: 
+    one: week
+    other: weeks
+  months: 
+    one: month
+    other: months
+  years:
+    one: year
+    other: years
   
   support:
     array:

--- a/spec/translations/es.yml
+++ b/spec/translations/es.yml
@@ -1,9 +1,0 @@
-es:
-  seconds: segundos
-  minutes: minutos
-  hours: horas
-  days: días
-  weeks: semanas
-  months: meses
-  years: años
-  

--- a/spec/translations/ru.yml
+++ b/spec/translations/ru.yml
@@ -1,0 +1,52 @@
+ru:
+  seconds: 
+    one: секунда
+    few: секунды
+    many: секунд
+    other: секунды
+  minutes: 
+    one: минута
+    few: минуты
+    many: минут
+    other: минуты
+  hours: 
+    one: час
+    few: часа
+    many: часов
+    other: часа
+  days: 
+    one: день
+    few: дня
+    many: дней
+    other: дня
+  weeks: 
+    one: неделя
+    few: недели
+    many: недель
+    other: недели
+  months: 
+    one: месяц
+    few: месяца
+    many: месяцев
+    other: месяца
+  years:
+    one: год
+    few: года
+    many: лет
+    other: года
+  
+  support:
+    array:
+      two_words_connector: " и "
+      words_connector: ", "
+      last_word_connector: " и "
+      
+  datetime:
+    distance_in_words:
+      about_x_years:
+        one: "около года"
+        many: "около %{count} лет"
+        
+  number:
+      format:
+        separator: ","


### PR DESCRIPTION
Hi radar,
I've modified I18n mechanism used it dotiw, so it allows translation to languages like russian and some other. The previously used :singularize => :always option didn't solve this issue.
Also I have added :highest_measures option which allows to pick some highest sequential measures. For example, :highest_measures => 2 can produce '2 years and 3 months', but it will never produce such awkward output like '2 years and 5 seconds'. :highest_measures => 1 is equal to :highest_measure_only, which is left for compatibility.
Please notice, locale files format has changed! This is the reason why I've removed spanish translation (I can't write updated one).