### PR TITLE
Timezone fix

### DIFF
--- a/dotiw.gemspec
+++ b/dotiw.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |s|
   s.summary = "Better distance_of_time_in_words for Rails"
   s.email = "radarlistener@gmail.com"
 
-  s.add_dependency "actionpack", "~> 3.0.0"
+  s.add_dependency "actionpack", "~> 3"
   
   s.add_development_dependency "bundler", "~> 1.0.0"
+  s.add_development_dependency "actionpack", "~> 3.0.0"
   s.add_development_dependency "rspec", "~> 2.0"
 
   s.files         = `git ls-files`.split("\n")

--- a/dotiw.gemspec
+++ b/dotiw.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary = "Better distance_of_time_in_words for Rails"
   s.email = "radarlistener@gmail.com"
 
-  s.add_dependency "actionpack", "~> 3"
+  s.add_dependency "actionpack", "~> 3.0.0"
   
   s.add_development_dependency "bundler", "~> 1.0.0"
   s.add_development_dependency "rspec", "~> 2.0"

--- a/lib/dotiw.rb
+++ b/lib/dotiw.rb
@@ -11,8 +11,8 @@ module ActionView
       alias_method :old_distance_of_time_in_words, :distance_of_time_in_words
 
       def distance_of_time_in_words_hash(from_time, to_time, options = {})
-        from_time = from_time.to_time if !from_time.is_a?(Time) && from_time.respond_to?(:to_time)
-        to_time   = to_time.to_time   if !to_time.is_a?(Time)   && to_time.respond_to?(:to_time)
+        from_time = from_time.utc.to_time if !from_time.is_a?(Time) && from_time.respond_to?(:to_time)
+        to_time   = to_time.utc.to_time   if !to_time.is_a?(Time)   && to_time.respond_to?(:to_time)
 
         DOTIW::TimeHash.new((from_time - to_time).abs, from_time, to_time, options).to_hash
       end

--- a/spec/lib/dotiw_spec.rb
+++ b/spec/lib/dotiw_spec.rb
@@ -88,6 +88,16 @@ describe "A better distance_of_time_in_words" do
         hash = distance_of_time_in_words_hash(Time.now, Time.now + 5.days)
         hash["días"].should eql(5)
       end
+
+      describe "given rfc822 formatted date" do
+        it "converts for non-utc time zones" do
+          time = DateTime.parse("Tue, 23 Oct 2012 13:38:09 -0700")
+          hash = distance_of_time_in_words_hash(time, (time + 1.hour + 22.minutes))
+
+          hash["hours"].should eql(1)
+          hash["minutes"].should eql(22)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
For reasons that I am not entirely clear on, if you have a DateTime object with an rfc822 date and a non-utc time zone, the difference calculations fail. This pull fixes that by first converting the time to utc. 

There is also a change to lock down the actionpack dependency so that the specs would run.