### PR TITLE
Ensure that action_view has been required

### DIFF
--- a/lib/dotiw.rb
+++ b/lib/dotiw.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'action_view'
 
 module DOTIW
   autoload :VERSION, 'dotiw/version'


### PR DESCRIPTION
This is only necessary when using ActionView::Helpers::DateHelper outside rails and is a no-op when using the gem in a Rails app.