### PR TITLE
Default locale will be the app's default locale;not necessarily English.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,7 +40,7 @@ Oh, and did I mention it supports I18n? Oh yeah. Rock on!
 
 #### :locale
 
-You can pass in a locale and it'll output it in whatever language you want (provided you have translations, otherwise it'll default to English):
+You can pass in a locale and it'll output it in whatever language you want (provided you have translations, otherwise it'll default to your app's default locale (the `config.i18n.default_locale` you have set in `/config/application.rb`):
 
     >> distance_of_time_in_words(Time.now, Time.now + 1.minute, false, :locale => :es)
     => "1 minuto"


### PR DESCRIPTION
I have set my app's default locale to :nb, and when I run:

>> helper.distance_of_time_in_words(Time.now, Time.now + 1.year + 2.months + 3.days + 4.hours + 5.minutes + 6.seconds, false)
=> "1 år, 2 måneder, 3 dager, 3 timer og 5 minutter"

which is using that default locale, and not english.