### PR TITLE
Fix issue #50

### DIFF
--- a/lib/dotiw/action_view_ext/helpers/date_helper.rb
+++ b/lib/dotiw/action_view_ext/helpers/date_helper.rb
@@ -5,7 +5,7 @@ module ActionView
 
       def distance_of_time_in_words_hash(from_time, to_time, options = {})
         from_time = from_time.to_time if !from_time.is_a?(Time) && from_time.respond_to?(:to_time)
-        to_time   = to_time.to_time   if !to_time.is_a?(Time)   && to_time.respond_to?(:to_time)
+        to_time = to_time.to_time if !to_time.is_a?(Time) && to_time.respond_to?(:to_time)
 
         DOTIW::TimeHash.new(nil, from_time, to_time, options).to_hash
       end
@@ -40,35 +40,46 @@ module ActionView
         distance_of_time_in_words(from_time, Time.now, include_seconds_or_options)
       end
 
-    private
+      private
       def display_time_in_words(hash, options = {})
         options.reverse_merge!(
-          :include_seconds => false
+            :include_seconds => false
         ).symbolize_keys!
 
         include_seconds = options.delete(:include_seconds)
         hash.delete(:seconds) if !include_seconds && hash[:minutes]
 
-        options[:except] = Array.wrap(options[:except]).map!(&:to_s) if options[:except]
-        options[:only] = Array.wrap(options[:only]).map!(&:to_s) if options[:only]
+        options[:except] = Array.wrap(options[:except]).map!(&:to_sym) if options[:except]
+        options[:only] = Array.wrap(options[:only]).map!(&:to_sym) if options[:only]
 
         # Remove all the values that are nil or excluded. Keep the required ones.
         hash.delete_if do |key, value|
           value.nil? || value.zero? ||
-            (options[:except] && options[:except].include?(key.to_s)) ||
-            (options[:only] && !options[:only].include?(key.to_s))
+              (options[:except] && options[:except].include?(key)) ||
+              (options[:only] && !options[:only].include?(key))
         end
-        return I18n.t('datetime.distance_in_words.less_than_x_seconds', :count => 1, :locale => options[:locale]) if hash.empty?
-
-        options.delete(:except)
-        options.delete(:only)
 
         i18n_scope = options.delete(:scope) || DOTIW::DEFAULT_I18N_SCOPE
+        if hash.empty?
+          fractions = DOTIW::TimeHash::TIME_FRACTIONS
+          fractions = fractions & options[:only] if options[:only]
+          fractions = fractions - options[:except] if options[:except]
+
+          I18n.with_options :locale => options[:locale], :scope => i18n_scope do |locale|
+            # e.g. try to format 'less than 1 days', fallback to '0 days'
+            return locale.translate :less_than_x,
+                                    :distance => locale.translate(fractions.first, :count => 1),
+                                    :default => locale.translate(fractions.first, :count => 0)
+          end
+        end
+
         output = []
         I18n.with_options :locale => options[:locale], :scope => i18n_scope do |locale|
           output = hash.map { |key, value| locale.t(key, :count => value) }
         end
 
+        options.delete(:except)
+        options.delete(:only)
         highest_measures = options.delete(:highest_measures)
         highest_measures = 1 if options.delete(:highest_measure_only)
         if highest_measures
@@ -76,14 +87,14 @@ module ActionView
         end
 
         options[:words_connector] ||= I18n.translate :'datetime.dotiw.words_connector',
-          :default => :'support.array.words_connector',
-          :locale => options[:locale]
+                                                     :default => :'support.array.words_connector',
+                                                     :locale => options[:locale]
         options[:two_words_connector] ||= I18n.translate :'datetime.dotiw.two_words_connector',
-          :default => :'support.array.two_words_connector',
-          :locale => options[:locale]
+                                                         :default => :'support.array.two_words_connector',
+                                                         :locale => options[:locale]
         options[:last_word_connector] ||= I18n.translate :'datetime.dotiw.last_word_connector',
-          :default => :'support.array.last_word_connector',
-          :locale => options[:locale]
+                                                         :default => :'support.array.last_word_connector',
+                                                         :locale => options[:locale]
 
         output.to_sentence(options)
       end

--- a/lib/dotiw/locale/de.yml
+++ b/lib/dotiw/locale/de.yml
@@ -22,3 +22,4 @@ de:
       years:
         one: 1 Jahr
         other: "%{count} Jahre"
+      less_than_x: "weniger als %{distance}"

--- a/lib/dotiw/locale/en.yml
+++ b/lib/dotiw/locale/en.yml
@@ -22,3 +22,4 @@ en:
       years:
         one: 1 year
         other: "%{count} years"
+      less_than_x: "less than %{distance}"

--- a/lib/dotiw/locale/es.yml
+++ b/lib/dotiw/locale/es.yml
@@ -22,3 +22,4 @@ es:
       years:
         one: un año
         other: "%{count} años"
+      less_than_x: "menos de %{distance}"

--- a/lib/dotiw/locale/nb.yml
+++ b/lib/dotiw/locale/nb.yml
@@ -22,3 +22,4 @@ nb:
       years:
         one: 1 år
         other: "%{count} år"
+      less_than_x: "mindre enn %{distance}"

--- a/lib/dotiw/locale/nl.yml
+++ b/lib/dotiw/locale/nl.yml
@@ -1,0 +1,25 @@
+nl:
+  datetime:
+    dotiw:
+      seconds:
+        one: 1 seconde
+        other: "%{count} seconden"
+      minutes:
+        one: 1 minuut
+        other: "%{count} minuten"
+      hours:
+        one: 1 uur
+        other: "%{count} uur"
+      days:
+        one: 1 dag
+        other: "%{count} dagen"
+      weeks:
+        one: 1 week
+        other: "%{count} weken"
+      months:
+        one: 1 maand
+        other: "%{count} maanden"
+      years:
+        one: 1 jaar
+        other: "%{count} jaar"
+      less_than_x: "minder dan %{distance}"

--- a/lib/dotiw/locale/pl.yml
+++ b/lib/dotiw/locale/pl.yml
@@ -29,3 +29,4 @@ pl:
         one: "1 rok"
         few: "%{count} lata"
         other: "%{count} lat"
+      less_than_x: "mniej niż %{distance}"

--- a/lib/dotiw/locale/ru.yml
+++ b/lib/dotiw/locale/ru.yml
@@ -36,3 +36,4 @@ ru:
         few:   "%{count} года"
         many:  "%{count} лет"
         other: "%{count} года"
+      less_than_x: "меньше %{distance}"

--- a/spec/lib/dotiw_spec.rb
+++ b/spec/lib/dotiw_spec.rb
@@ -77,8 +77,8 @@ describe "A better distance_of_time_in_words" do
 
   describe "real version" do
     it "debe hablar español" do
-      expect(distance_of_time_in_words(START_TIME, START_TIME + 1.days, true, :locale => :es)).to eq("un día")
-      expect(distance_of_time_in_words(START_TIME, START_TIME + 5.days, true, :locale => :es)).to eq("5 días")
+      expect(distance_of_time_in_words(START_TIME, START_TIME + 1.days, :locale => :es)).to eq("un día")
+      expect(distance_of_time_in_words(START_TIME, START_TIME + 5.days, :locale => :es)).to eq("5 días")
     end
 
     fragments = [
@@ -228,7 +228,19 @@ describe "A better distance_of_time_in_words" do
       [START_TIME,
        START_TIME + 1.year + 2.weeks,
        { :highest_measures => 3 },
-       "1 year and 14 days"]
+       "1 year and 14 days"],
+      [START_TIME,
+       START_TIME + 1.days,
+       { :only => [:years, :months] },
+       "less than 1 month"],
+      [START_TIME,
+       START_TIME + 5.minutes,
+       { :except => [:hours, :minutes, :seconds] },
+       "less than 1 day"],
+      [START_TIME,
+       START_TIME + 1.days,
+       { :highest_measures => 1, :only => [:years, :months] },
+       "less than 1 month"]
     ]
     fragments.each do |start, finish, options, output|
       it "should be #{output}" do


### PR DESCRIPTION
Resolves issue #50. 'Less than X' output now respects ```:except``` and ```:only``` options.
Output will fall back to '0 X' (e.g. 0 months) if 'less than X' translation is not in current locale.