### PR TITLE
Fixes for russian locale

### DIFF
--- a/lib/dotiw/locale/ru.yml
+++ b/lib/dotiw/locale/ru.yml
@@ -2,38 +2,38 @@ ru:
   datetime:
     dotiw:
       seconds:
-        one:   1 секунда
+        one:   "%{count} секунда"
         few:   "%{count} секунды"
         many:  "%{count} секунд"
         other: "%{count} секунды"
       minutes:
-        one:   1 минута
+        one:   "%{count} минута"
         few:   "%{count} минуты"
         many:  "%{count} минут"
         other: "%{count} минуты"
       hours:
-        one:   1 час
+        one:   "%{count} час"
         few:   "%{count} часа"
         many:  "%{count} часов"
         other: "%{count} часа"
       days:
-        one:   1 день
+        one:   "%{count} день"
         few:   "%{count} дня"
         many:  "%{count} дней"
         other: "%{count} дня"
       weeks:
-        one:   1 неделя
+        one:   "%{count} неделя"
         few:   "%{count} недели"
         many:  "%{count} недель"
         other: "%{count} недели"
       months:
-        one:   1 месяц
+        one:   "%{count} месяц"
         few:   "%{count} месяца"
         many:  "%{count} месяцев"
-        other: "%{count} месяцы"
+        other: "%{count} месяца"
       years:
-        one:   1 год
+        one:   "%{count} год"
         few:   "%{count} года"
         many:  "%{count} лет"
         other: "%{count} года"
-      less_than_x: "меньше %{distance}"
+      less_than_x: "меньше, чем %{distance}"


### PR DESCRIPTION
 1. Fix for numbers that counts as one (21, 31, etc),

    See <http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html#ru>

    Fixes #55

 2. Reword of `less_than_x` options to match distance's nominative case