### PR TITLE
Use Time.current instead of Time.now

### DIFF
--- a/lib/dotiw/action_view_ext/helpers/date_helper.rb
+++ b/lib/dotiw/action_view_ext/helpers/date_helper.rb
@@ -37,7 +37,7 @@ module ActionView
       alias_method :old_time_ago_in_words, :time_ago_in_words
 
       def time_ago_in_words(from_time, include_seconds_or_options = {})
-        distance_of_time_in_words(from_time, Time.now, include_seconds_or_options)
+        distance_of_time_in_words(from_time, Time.current, include_seconds_or_options)
       end
 
       private

--- a/lib/dotiw/time_hash.rb
+++ b/lib/dotiw/time_hash.rb
@@ -10,7 +10,7 @@ module DOTIW
       self.output     = ActiveSupport::OrderedHash.new
       self.options    = options
       self.distance   = distance
-      self.from_time  = from_time || Time.now
+      self.from_time  = from_time || Time.current
       self.to_time    = to_time   || (@to_time_not_given = true && self.from_time + self.distance.seconds)
       self.smallest, self.largest = [self.from_time, self.to_time].minmax
       self.to_time   += 1.hour if @to_time_not_given && self.smallest.dst? && !self.largest.dst?


### PR DESCRIPTION
This fixes issues with timezones especially when the server is in a different locale than the client.